### PR TITLE
fix: set up buildx driver required by the gha build cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,12 @@ jobs:
           SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
           echo "tag=${BRANCH_NAME}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
+      # Required for cache-to: type=gha below. The runner's default buildx driver
+      # is `docker`, which cannot export a cache ("Cache export is not supported
+      # for the docker driver"); this sets up the docker-container driver.
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Follow-up to #14.

The post-merge staging run failed at `Build and push image`:

```
ERROR: failed to build: Cache export is not supported for the docker driver.
```

`cache-from`/`cache-to: type=gha` were added in #14 without the accompanying
`docker/setup-buildx-action` step, so the runner stayed on the default `docker`
buildx driver, which cannot export a cache. The build failed before the
Dockerfile was even read.

Adds the missing setup step. Keeps the cache rather than dropping it — the
Dockerfile's `pip install` layer is the slow part of every build.

## Verification status

`checks` passed on the previous run, and the `STATIC_ROOT` fix from #14 is
confirmed against the real failure (`ImproperlyConfigured` in `staging_web`
logs, memory ruled out at 1540MB available).

Nothing past `build-and-push` has run yet, so the deploy path — env generation,
`pg_dump`, migration, health check — is still unverified. This run is the first
that reaches it, and it also exercises the slimmed Dockerfile
(`build-essential`/`libpq-dev` removed) for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)